### PR TITLE
removed robots.txt file to improve SEO

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,2 +1,0 @@
-user-agent: *
-disallow: /


### PR DESCRIPTION

Robots.txt was inadvertently added disallowing web crawlers, which hurts doc SEO.

