### PR TITLE
Fix TxV delivery: dispatch administer() by product family

### DIFF
--- a/hpvsim/interventions.py
+++ b/hpvsim/interventions.py
@@ -503,7 +503,15 @@ class BaseTxVx(BaseTreatment):
         """One-step delivery — finds accepters, administers, bumps counters."""
         accept_uids = self.get_accept_inds()
         if len(accept_uids):
-            self.product.administer(self.sim.people, accept_uids)
+            # Products use two administer conventions: ss.Vx-based (hpv.vx,
+            # hpv.txvx) take (people, uids); ss.Tx/ss.Dx (hpv.tx, hpv.dx) take
+            # (uids, ...). A TxV can be modelled either as an immunity hpv.txvx
+            # OR (faithfully to v2) as an hpv.tx state-flip product, so dispatch
+            # on the product type rather than assuming (people, uids).
+            if isinstance(self.product, ss.Vx):
+                self.product.administer(self.sim.people, accept_uids)
+            else:
+                self.product.administer(accept_uids)
             new = accept_uids[~self.tx_vaccinated[accept_uids]]
             self.tx_vaccinated[accept_uids] = True
             self.txvx_doses[accept_uids] += 1


### PR DESCRIPTION
## Problem
`BaseTxVx.deliver` unconditionally called `self.product.administer(self.sim.people, accept_uids)` — the `ss.Vx` convention `(people, uids)`. But a therapeutic vaccine can be modelled as an `hpv.tx` **state-flip** product (`ss.Tx`), whose signature is `administer(uids, return_format=...)`. That product then received `sim.people` as `uids`, so `_state_uids_for_module` intersected a Person collection and `np.unique` failed:

```
hpvsim/interventions.py:518 step -> :506 deliver -> products.py:429 administer
  -> products.py:_state_uids_for_module -> arr.uids.intersect(uids) -> np.unique(...)
TypeError: '<' not supported between instances of 'Person' and 'Person'
```

This crashes every scenario that delivers a `campaign_txvx`/`routine_txvx` backed by an `hpv.tx` product (e.g. the Rwanda HIV–HPV therapeutic-vaccine scenarios). `hpv.tx`/`hpv.dx` treatment products used elsewhere are unaffected, which is why it was isolated to the TxV path.

## Fix
Dispatch on the product family, matching Starsim's own convention (its `ss.Vx` interventions call `(people, uids)`; its `ss.Tx`/`ss.Dx` interventions call `(uids)`):

```python
if isinstance(self.product, ss.Vx):
    self.product.administer(self.sim.people, accept_uids)
else:
    self.product.administer(accept_uids)
```

No product signatures change (they already match their Starsim bases). The only fix is at the one polymorphic call site.

## Testing
Full non-slow suite **331 passed** (`pytest -m "not slow"`). Targeted intervention tests (txvx / treatment / screening / vx / cascade) all green. Verified end-to-end: the Rwanda full 23-scenario HIV set (which previously crashed on the TxV/HPV-Faster scenarios) now runs to completion.

Surfaced by the v2→v3 analysis-repo migration review.